### PR TITLE
FeignClient 사용

### DIFF
--- a/user-service/pom.xml
+++ b/user-service/pom.xml
@@ -97,6 +97,12 @@
             <groupId>org.springframework.cloud</groupId>
             <artifactId>spring-cloud-starter-bus-amqp</artifactId>
         </dependency>
+
+        <!-- open feign -->
+        <dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-starter-openfeign</artifactId>
+        </dependency>
     </dependencies>
     <dependencyManagement>
         <dependencies>

--- a/user-service/src/main/java/com/example/userservice/UserServiceApplication.java
+++ b/user-service/src/main/java/com/example/userservice/UserServiceApplication.java
@@ -1,17 +1,20 @@
 package com.example.userservice;
 
+import feign.Logger;
 import javax.sql.DataSource;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
 import org.springframework.cloud.client.loadbalancer.LoadBalanced;
+import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.context.annotation.Bean;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.web.client.RestTemplate;
 
 @SpringBootApplication
 @EnableDiscoveryClient
+@EnableFeignClients
 public class UserServiceApplication {
 
     public static void main(String[] args) {
@@ -34,5 +37,10 @@ public class UserServiceApplication {
     @LoadBalanced
     public RestTemplate getRestTemplate() {
         return new RestTemplate();
+    }
+
+    @Bean
+    public Logger.Level feignLoggerLevel() {
+        return Logger.Level.FULL;
     }
 }

--- a/user-service/src/main/java/com/example/userservice/client/OrderServiceClient.java
+++ b/user-service/src/main/java/com/example/userservice/client/OrderServiceClient.java
@@ -1,0 +1,14 @@
+package com.example.userservice.client;
+
+import com.example.userservice.vo.ResponseOrder;
+import java.util.List;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+
+@FeignClient(name = "order-service")
+public interface OrderServiceClient {
+
+    @GetMapping("/order-service/{userId}/orders")
+    List<ResponseOrder> getOrders(@PathVariable String userId);
+}

--- a/user-service/src/main/java/com/example/userservice/service/UserServiceImpl.java
+++ b/user-service/src/main/java/com/example/userservice/service/UserServiceImpl.java
@@ -1,5 +1,6 @@
 package com.example.userservice.service;
 
+import com.example.userservice.client.OrderServiceClient;
 import com.example.userservice.dto.UserDto;
 import com.example.userservice.jpa.UserEntity;
 import com.example.userservice.jpa.UserRepository;
@@ -10,10 +11,7 @@ import java.util.UUID;
 import lombok.extern.slf4j.Slf4j;
 import org.modelmapper.ModelMapper;
 import org.modelmapper.convention.MatchingStrategies;
-import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.core.env.Environment;
-import org.springframework.http.HttpMethod;
-import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.userdetails.User;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
@@ -32,12 +30,15 @@ public class UserServiceImpl implements UserService {
 
     RestTemplate restTemplate;
 
+    OrderServiceClient orderServiceClient;
+
     public UserServiceImpl(Environment env, UserRepository userRepository, BCryptPasswordEncoder passwordEncoder,
-                           RestTemplate restTemplate) {
+                           RestTemplate restTemplate, OrderServiceClient orderServiceClient) {
         this.env = env;
         this.userRepository = userRepository;
         this.passwordEncoder = passwordEncoder;
         this.restTemplate = restTemplate;
+        this.orderServiceClient = orderServiceClient;
     }
 
     @Override
@@ -79,12 +80,17 @@ public class UserServiceImpl implements UserService {
 
         UserDto userDto = new ModelMapper().map(userEntity, UserDto.class);
 
-        String orderUrl = String.format(env.getProperty("order-service.url"), userId);
-        ResponseEntity<List<ResponseOrder>> orderListResponse =
-                restTemplate.exchange(orderUrl, HttpMethod.GET, null,
-                        new ParameterizedTypeReference<List<ResponseOrder>>() {
-                        });
-        List<ResponseOrder> orderList = orderListResponse.getBody();
+        // Using a restTemplate
+//        String orderUrl = String.format(env.getProperty("order-service.url"), userId);
+//        ResponseEntity<List<ResponseOrder>> orderListResponse =
+//                restTemplate.exchange(orderUrl, HttpMethod.GET, null,
+//                        new ParameterizedTypeReference<List<ResponseOrder>>() {
+//                        });
+//        List<ResponseOrder> orderList = orderListResponse.getBody();
+        
+        // Using a feignclient
+        List<ResponseOrder> orderList = orderServiceClient.getOrders(userId);
+
         userDto.setOrders(orderList);
 
         return userDto;

--- a/user-service/src/main/resources/application.yml
+++ b/user-service/src/main/resources/application.yml
@@ -30,6 +30,10 @@ spring:
       name: user
       password: $2a$10$gsF97/VPwBZrIibP7rIqX.BhmX9cX2/aJxRPuRj85cbrHWcfNA6r6
 
+logging:
+  level:
+    org.springframework.security: DEBUG
+    com.example.userservice.client: DEBUG
 
 eureka:
   instance:


### PR DESCRIPTION
## 변경 사항
REST Call을 추상화하는 Spring Cloud Netflix 라이브러리이다. 로드 밸런싱을 지원한다. RestTemplate보다 직관적이고 추상적인 방법으로 계층의 책임을 지키며 통신을 사용할 수 있다.
### 의존성 추가
```
<dependency>
	<groupId>org.springframework.cloud</groupId>
	<artifactId>spring-cloud-start-openfeign</artifactId>
</dependency>
```
### @EnableFeignClients 추가
```
@EnableFeignClients
public class UserServiceApplication { }
```
### 호출하려는 HTTP Endpoint에 대한 @FeignClient 인터페이스 생성
```
@FeignClient(name = "order-service")
public interface OrderServiceClient {

    @GetMapping("/order-service/{userId}/orders")
    List<ResponseOrder> getOrders(@PathVariable String userId);
}
```
### 서비스에서 사용
```
@RequiredArgsConstructor
@Service
public class UserServiceImpl implements UserService {

    private final OrderServiceClient orderServiceClient;

    @Override
    public UserDto getUserByUserId(String userId) {
        UserEntity userEntity = userRepository.findByUserId(userId)
                .orElseThrow(() -> new UsernameNotFoundException("User not found"));
        UserDto userDto = modelMapper.map(userEntity, UserDto.class);

        // feign client 사용
        userDto.setOrders(orderServiceClient.getOrders(userId));
        return userDto;
    }

}
```
### FeignClient 로그 사용
- 로그 추적 설정
```
logging:
	level:
		com.example.userservice.client: DEBUG
```
- 로그 빈 등록
```
import feign.Logger;

@Bean
public Logger.Level fieldLoggerLevel() {
	return Logger.Level.FULL;
}
```