### PR TITLE
FeignClient 예외처리-ErrorDecorder

### DIFF
--- a/user-service/src/main/java/com/example/userservice/UserServiceApplication.java
+++ b/user-service/src/main/java/com/example/userservice/UserServiceApplication.java
@@ -43,4 +43,9 @@ public class UserServiceApplication {
     public Logger.Level feignLoggerLevel() {
         return Logger.Level.FULL;
     }
+
+    //	@Bean
+//	public FeignErrorDecoder getFeignErrorDecoder() {
+//		return new FeignErrorDecoder();
+//	}
 }

--- a/user-service/src/main/java/com/example/userservice/client/OrderServiceClient.java
+++ b/user-service/src/main/java/com/example/userservice/client/OrderServiceClient.java
@@ -1,12 +1,13 @@
 package com.example.userservice.client;
 
+import com.example.userservice.error.FeignErrorDecoder;
 import com.example.userservice.vo.ResponseOrder;
 import java.util.List;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 
-@FeignClient(name = "order-service")
+@FeignClient(name = "order-service", configuration = FeignErrorDecoder.class)
 public interface OrderServiceClient {
 
     @GetMapping("/order-service/{userId}/orders")

--- a/user-service/src/main/java/com/example/userservice/error/FeignErrorDecoder.java
+++ b/user-service/src/main/java/com/example/userservice/error/FeignErrorDecoder.java
@@ -1,0 +1,39 @@
+package com.example.userservice.error;
+
+import feign.Response;
+import feign.codec.ErrorDecoder;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.env.Environment;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Component;
+import org.springframework.web.server.ResponseStatusException;
+
+@Component
+public class FeignErrorDecoder implements ErrorDecoder {
+    Environment env;
+
+    @Autowired
+    public FeignErrorDecoder(Environment env) {
+        this.env = env;
+    }
+
+    @Override
+    public Exception decode(String methodKey, Response response) {
+        switch (response.status()) {
+            case 400:
+                break;
+            case 404:
+                if (methodKey.contains("getOrders")) {
+                    return new ResponseStatusException(HttpStatus.valueOf(response.status()),
+//                            "User's orders is empty");
+                            env.getProperty("order-service.exception.order-is-empty")
+                    );
+                }
+                break;
+            default:
+                return new Exception(response.reason());
+        }
+
+        return null;
+    }
+}


### PR DESCRIPTION
## 추가 사항
Feign Client로부터 받은 응답 결과 코드를 받아서 유저 서비스의 예외로 변환하는 ErrorDecorder 인터페이스를 구현
- ErrorDecoder 정의
```
@Component
public class FeignErrorDecoder implements ErrorDecoder {
    Environment env;

    @Autowired
    public FeignErrorDecoder(Environment env) {
        this.env = env;
    }

    @Override
    public Exception decode(String methodKey, Response response) {
        switch (response.status()) {
            case 400:
                break;
            case 404:
                if (methodKey.contains("getOrders")) {
                    return new ResponseStatusException(HttpStatus.valueOf(response.status()),
//                            "User's orders is empty");
                            env.getProperty("order-service.exception.order-is-empty")
                    );
                }
                break;
            default:
                return new Exception(response.reason());
        }

        return null;
    }
}
```
- config server의 user-service.yml 변경
```
order_service:
  url: http://ORDER-SERVICE/order-service/%s/orders
  exception:
    orders-is-empty: User's order is empty.
```